### PR TITLE
Fail health check on non-ok responses

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,20 +1,20 @@
 package main
 
 import (
-        "fmt"
-        "log"
-        "net/http"
-        "os"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
 )
 
 func main() {
-        if len(os.Args) < 2 {
-                log.Fatal("Expected URL as command-line argument")
-                os.Exit(1)
-        }
-        url := os.Args[1]
-        fmt.Println(url)
-        if _, err := http.Get(url); err != nil {
-                os.Exit(1)
-        }
+	if len(os.Args) < 2 {
+		log.Fatal("Expected URL as command-line argument")
+		os.Exit(1)
+	}
+	url := os.Args[1]
+	fmt.Println(url)
+	if resp, err := http.Get(url); err != nil || resp.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -13,7 +12,6 @@ func main() {
 		os.Exit(1)
 	}
 	url := os.Args[1]
-	fmt.Println(url)
 	if resp, err := http.Get(url); err != nil || resp.StatusCode != http.StatusOK {
 		os.Exit(1)
 	}


### PR DESCRIPTION
- Sets the tab size to 4
- Exits with 1 if http status code isn't Ok.